### PR TITLE
Fix mobile menu display and positioning issues

### DIFF
--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -270,6 +270,7 @@
   width: 100vw !important;
   height: 100vh !important;
   background: #ffffff !important;
+  border: 5px solid red !important;
   z-index: 10000 !important;
   transition: left 0.3s ease !important;
   display: flex !important;

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -275,6 +275,7 @@
 
 .mobile-menu-open {
   transform: translateX(0);
+  visibility: visible;
 }
 
 .mobile-menu-content {

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -278,12 +278,12 @@
   justify-content: center !important;
 }
 
-[data-theme="dark"] .mobile-menu {
-  background: rgba(15, 23, 42, 0.98);
+[data-theme="dark"] .navbar .mobile-menu {
+  background: rgba(15, 23, 42, 0.98) !important;
 }
 
-.mobile-menu-open {
-  transform: translateX(0);
+.navbar .mobile-menu.mobile-menu-open {
+  transform: translateX(0) !important;
 }
 
 .mobile-menu-content {

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -263,19 +263,19 @@
 }
 
 /* Mobile Menu */
-.mobile-menu {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(255, 255, 255, 0.98);
-  z-index: 9999;
-  transform: translateX(-100%);
-  transition: transform 0.3s ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.navbar .mobile-menu {
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  width: 100vw !important;
+  height: 100vh !important;
+  background: rgba(255, 255, 255, 0.98) !important;
+  z-index: 9999 !important;
+  transform: translateX(-100%) !important;
+  transition: transform 0.3s ease !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
 }
 
 [data-theme="dark"] .mobile-menu {

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -268,8 +268,9 @@
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   transform: translateX(-100%);
-  transition: transform var(--transition-base);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   z-index: var(--z-modal-backdrop);
+  visibility: hidden;
 }
 
 .mobile-menu-open {

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -236,8 +236,9 @@
   width: 24px;
   height: 2px;
   background: var(--text-primary);
-  transition: all var(--transition-base);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   transform-origin: center;
+  border-radius: 1px;
 }
 
 .hamburger-line:not(:last-child) {

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -233,12 +233,16 @@
 }
 
 .hamburger-line {
-  width: 24px;
-  height: 2px;
-  background: var(--text-primary);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  width: 25px;
+  height: 3px;
+  background: #333;
+  transition: all 0.3s ease;
   transform-origin: center;
-  border-radius: 1px;
+  border-radius: 2px;
+}
+
+[data-theme="dark"] .hamburger-line {
+  background: #fff;
 }
 
 .hamburger-line:not(:last-child) {

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -227,8 +227,9 @@
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  padding: 8px;
   z-index: var(--z-modal);
+  position: relative;
 }
 
 .hamburger-line {

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -297,10 +297,12 @@
   font-family: var(--font-display);
   font-size: var(--text-3xl);
   font-weight: 600;
-  color: var(--text-primary);
+  color: #ffffff;
   text-decoration: none;
   transition: all var(--transition-base);
   position: relative;
+  padding: var(--space-4);
+  text-align: center;
 }
 
 .mobile-nav-link:hover,

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -265,18 +265,20 @@
   left: 0;
   width: 100vw;
   height: 100vh;
-  background: var(--bg-overlay);
+  background: rgba(15, 23, 42, 0.95);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   transform: translateX(-100%);
   transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  z-index: var(--z-modal-backdrop);
+  z-index: 1050;
   visibility: hidden;
+  opacity: 0;
 }
 
 .mobile-menu-open {
-  transform: translateX(0);
-  visibility: visible;
+  transform: translateX(0) !important;
+  visibility: visible !important;
+  opacity: 1 !important;
 }
 
 .mobile-menu-content {

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -287,11 +287,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100%;
-  gap: var(--space-8);
-  padding: var(--space-8);
-  position: relative;
-  z-index: 1051;
+  gap: 2rem;
+  padding: 2rem;
 }
 
 .mobile-nav-link {

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -222,13 +222,13 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  width: 30px;
-  height: 30px;
+  width: 40px;
+  height: 40px;
   background: none;
   border: none;
   cursor: pointer;
   padding: 8px;
-  z-index: 1052;
+  z-index: 9999;
   position: relative;
 }
 

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -279,7 +279,7 @@
 }
 
 [data-theme="dark"] .mobile-menu {
-  background: #1e293b !important;
+  background: rgba(15, 23, 42, 0.98) !important;
 }
 
 .mobile-menu-open {

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -269,8 +269,8 @@
   left: -100vw !important;
   width: 100vw !important;
   height: 100vh !important;
-  background: #ffffff !important;
-  border: 5px solid red !important;
+  background: rgba(255, 255, 255, 0.98) !important;
+  backdrop-filter: blur(10px) !important;
   z-index: 10000 !important;
   transition: left 0.3s ease !important;
   display: flex !important;

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -301,12 +301,16 @@
   font-family: var(--font-display);
   font-size: var(--text-3xl);
   font-weight: 600;
-  color: #ffffff;
+  color: var(--text-primary);
   text-decoration: none;
   transition: all var(--transition-base);
   position: relative;
   padding: var(--space-4);
   text-align: center;
+}
+
+[data-theme="dark"] .mobile-nav-link {
+  color: #ffffff;
 }
 
 .mobile-nav-link:hover,

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -39,6 +39,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  position: relative;
 }
 
 /* Brand Section */

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -289,6 +289,8 @@
   height: 100%;
   gap: var(--space-8);
   padding: var(--space-8);
+  position: relative;
+  z-index: 1051;
 }
 
 .mobile-nav-link {

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -265,24 +265,21 @@
   left: 0;
   width: 100vw;
   height: 100vh;
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
+  background: rgba(255, 255, 255, 0.98);
+  z-index: 9999;
   transform: translateX(-100%);
-  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  z-index: 1050;
-  visibility: hidden;
-  opacity: 0;
+  transition: transform 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 [data-theme="dark"] .mobile-menu {
-  background: rgba(15, 23, 42, 0.95);
+  background: rgba(15, 23, 42, 0.98);
 }
 
 .mobile-menu-open {
-  transform: translateX(0) !important;
-  visibility: visible !important;
-  opacity: 1 !important;
+  transform: translateX(0);
 }
 
 .mobile-menu-content {

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -291,19 +291,24 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 2rem;
+  gap: 3rem;
   padding: 2rem;
+  height: 100%;
 }
 
 .mobile-nav-link {
-  font-size: 2rem;
+  font-family: var(--font-display);
+  font-size: 2.5rem;
   font-weight: 600;
-  color: #333;
+  color: var(--text-primary);
   text-decoration: none;
-  padding: 1rem 2rem;
+  padding: 1.5rem 2rem;
   text-align: center;
-  border-radius: 8px;
+  border-radius: 12px;
   transition: all 0.3s ease;
+  position: relative;
+  text-transform: uppercase;
+  letter-spacing: 1px;
 }
 
 [data-theme="dark"] .mobile-nav-link {
@@ -313,7 +318,25 @@
 .mobile-nav-link:hover,
 .mobile-nav-link.active {
   background: rgba(37, 99, 235, 0.1);
-  color: #2563eb;
+  color: var(--color-primary);
+  transform: scale(1.05);
+}
+
+.mobile-nav-link::after {
+  content: '';
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  width: 0;
+  height: 3px;
+  background: var(--color-primary);
+  transition: all 0.3s ease;
+  transform: translateX(-50%);
+}
+
+.mobile-nav-link:hover::after,
+.mobile-nav-link.active::after {
+  width: 60%;
 }
 
 .mobile-nav-link:hover,

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -297,54 +297,50 @@
 .mobile-menu-content {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 3rem;
-  padding: 2rem;
-  height: 100%;
+  padding: 1rem 0;
 }
 
 .mobile-nav-link {
-  font-family: var(--font-display);
-  font-size: 2.5rem;
-  font-weight: 600;
+  font-size: 1.1rem;
+  font-weight: 500;
   color: var(--text-primary);
   text-decoration: none;
-  padding: 1.5rem 2rem;
-  text-align: center;
-  border-radius: 12px;
-  transition: all 0.3s ease;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--border-primary);
+  transition: all 0.2s ease;
   position: relative;
-  text-transform: uppercase;
-  letter-spacing: 1px;
+}
+
+.mobile-nav-link:last-child {
+  border-bottom: none;
 }
 
 [data-theme="dark"] .mobile-nav-link {
-  color: #ffffff;
+  color: var(--text-primary);
+  border-color: var(--border-secondary);
 }
 
 .mobile-nav-link:hover,
 .mobile-nav-link.active {
-  background: rgba(37, 99, 235, 0.1);
-  color: var(--color-primary);
-  transform: scale(1.05);
+  background: var(--color-primary);
+  color: white;
+  padding-left: 2rem;
 }
 
-.mobile-nav-link::after {
+.mobile-nav-link::before {
   content: '';
   position: absolute;
-  bottom: 8px;
-  left: 50%;
+  left: 0;
+  top: 0;
+  bottom: 0;
   width: 0;
-  height: 3px;
   background: var(--color-primary);
-  transition: all 0.3s ease;
-  transform: translateX(-50%);
+  transition: width 0.2s ease;
 }
 
-.mobile-nav-link:hover::after,
-.mobile-nav-link.active::after {
-  width: 60%;
+.mobile-nav-link:hover::before,
+.mobile-nav-link.active::before {
+  width: 4px;
 }
 
 .mobile-nav-link:hover,

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -228,7 +228,7 @@
   border: none;
   cursor: pointer;
   padding: 8px;
-  z-index: var(--z-modal);
+  z-index: 1052;
   position: relative;
 }
 

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -351,15 +351,15 @@
   }
 
   .desktop-only {
-    display: none;
+    display: none !important;
   }
 
   .mobile-only {
-    display: flex;
+    display: flex !important;
   }
 
   .hamburger {
-    display: flex;
+    display: flex !important;
   }
 
   .brand-name {

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -292,19 +292,24 @@
 }
 
 .mobile-nav-link {
-  font-family: var(--font-display);
-  font-size: var(--text-3xl);
+  font-size: 2rem;
   font-weight: 600;
-  color: var(--text-primary);
+  color: #333;
   text-decoration: none;
-  transition: all var(--transition-base);
-  position: relative;
-  padding: var(--space-4);
+  padding: 1rem 2rem;
   text-align: center;
+  border-radius: 8px;
+  transition: all 0.3s ease;
 }
 
 [data-theme="dark"] .mobile-nav-link {
   color: #ffffff;
+}
+
+.mobile-nav-link:hover,
+.mobile-nav-link.active {
+  background: rgba(37, 99, 235, 0.1);
+  color: #2563eb;
 }
 
 .mobile-nav-link:hover,

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -263,27 +263,26 @@
 }
 
 /* Mobile Menu */
-.navbar .mobile-menu {
+.mobile-menu {
   position: fixed !important;
   top: 0 !important;
-  left: 0 !important;
+  left: -100vw !important;
   width: 100vw !important;
   height: 100vh !important;
-  background: rgba(255, 255, 255, 0.98) !important;
-  z-index: 9999 !important;
-  transform: translateX(-100%) !important;
-  transition: transform 0.3s ease !important;
+  background: #ffffff !important;
+  z-index: 10000 !important;
+  transition: left 0.3s ease !important;
   display: flex !important;
   align-items: center !important;
   justify-content: center !important;
 }
 
-[data-theme="dark"] .navbar .mobile-menu {
-  background: rgba(15, 23, 42, 0.98) !important;
+[data-theme="dark"] .mobile-menu {
+  background: #1e293b !important;
 }
 
-.navbar .mobile-menu.mobile-menu-open {
-  transform: translateX(0) !important;
+.mobile-menu-open {
+  left: 0 !important;
 }
 
 .mobile-menu-content {

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -264,26 +264,34 @@
 
 /* Mobile Menu */
 .mobile-menu {
-  position: fixed !important;
-  top: 0 !important;
-  left: -100vw !important;
-  width: 100vw !important;
-  height: 100vh !important;
-  background: rgba(255, 255, 255, 0.98) !important;
-  backdrop-filter: blur(10px) !important;
+  position: absolute !important;
+  top: 100% !important;
+  left: 0 !important;
+  right: 0 !important;
+  width: 100% !important;
+  background: var(--bg-card) !important;
+  border: 1px solid var(--border-primary) !important;
+  border-radius: 0 0 12px 12px !important;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15) !important;
   z-index: 10000 !important;
-  transition: left 0.3s ease !important;
-  display: flex !important;
-  align-items: center !important;
-  justify-content: center !important;
+  opacity: 0 !important;
+  visibility: hidden !important;
+  transform: translateY(-10px) !important;
+  transition: all 0.3s ease !important;
+  max-height: 0 !important;
+  overflow: hidden !important;
 }
 
 [data-theme="dark"] .mobile-menu {
-  background: rgba(15, 23, 42, 0.98) !important;
+  background: var(--bg-secondary) !important;
+  border-color: var(--border-secondary) !important;
 }
 
 .mobile-menu-open {
-  left: 0 !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+  transform: translateY(0) !important;
+  max-height: 400px !important;
 }
 
 .mobile-menu-content {

--- a/my-real-estate-app/src/components/Navbar.css
+++ b/my-real-estate-app/src/components/Navbar.css
@@ -265,7 +265,7 @@
   left: 0;
   width: 100vw;
   height: 100vh;
-  background: rgba(15, 23, 42, 0.95);
+  background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   transform: translateX(-100%);
@@ -273,6 +273,10 @@
   z-index: 1050;
   visibility: hidden;
   opacity: 0;
+}
+
+[data-theme="dark"] .mobile-menu {
+  background: rgba(15, 23, 42, 0.95);
 }
 
 .mobile-menu-open {

--- a/my-real-estate-app/src/components/Navbar.jsx
+++ b/my-real-estate-app/src/components/Navbar.jsx
@@ -18,11 +18,7 @@ const Navbar = () => {
   }, []);
 
   const handleMenuToggle = () => {
-    console.log('Hamburger clicked! Current menuOpen:', menuOpen);
-    setMenuOpen((open) => {
-      console.log('Previous state:', open, 'New state:', !open);
-      return !open;
-    });
+    setMenuOpen((open) => !open);
 
     // Add haptic feedback for mobile devices
     if ('vibrate' in navigator) {

--- a/my-real-estate-app/src/components/Navbar.jsx
+++ b/my-real-estate-app/src/components/Navbar.jsx
@@ -113,6 +113,18 @@ const Navbar = () => {
 
         <div className={`mobile-menu ${menuOpen ? 'mobile-menu-open' : ''}`}>
           <div className="mobile-menu-content">
+            <div style={{
+              position: 'absolute',
+              top: '20px',
+              left: '20px',
+              background: 'red',
+              color: 'white',
+              padding: '10px',
+              fontSize: '16px',
+              fontWeight: 'bold'
+            }}>
+              Menu is {menuOpen ? 'OPEN' : 'CLOSED'}
+            </div>
             {navItems.map((item) => (
               <Link
                 key={item.path}

--- a/my-real-estate-app/src/components/Navbar.jsx
+++ b/my-real-estate-app/src/components/Navbar.jsx
@@ -99,10 +99,12 @@ const Navbar = () => {
           ))}
         </div>
 
-        <button 
-          className="hamburger mobile-only" 
-          onClick={handleMenuToggle} 
+        <button
+          className="hamburger mobile-only"
+          onClick={handleMenuToggle}
           aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+          aria-expanded={menuOpen}
+          type="button"
         >
           <span className={`hamburger-line ${menuOpen ? 'open' : ''}`}></span>
           <span className={`hamburger-line ${menuOpen ? 'open' : ''}`}></span>

--- a/my-real-estate-app/src/components/Navbar.jsx
+++ b/my-real-estate-app/src/components/Navbar.jsx
@@ -18,11 +18,7 @@ const Navbar = () => {
   }, []);
 
   const handleMenuToggle = () => {
-    console.log('Hamburger clicked, current menuOpen:', menuOpen);
-    setMenuOpen((open) => {
-      console.log('Setting menuOpen to:', !open);
-      return !open;
-    });
+    setMenuOpen((open) => !open);
 
     // Add haptic feedback for mobile devices
     if ('vibrate' in navigator) {

--- a/my-real-estate-app/src/components/Navbar.jsx
+++ b/my-real-estate-app/src/components/Navbar.jsx
@@ -113,18 +113,6 @@ const Navbar = () => {
 
         <div className={`mobile-menu ${menuOpen ? 'mobile-menu-open' : ''}`}>
           <div className="mobile-menu-content">
-            <div style={{
-              position: 'absolute',
-              top: '20px',
-              left: '20px',
-              background: 'red',
-              color: 'white',
-              padding: '10px',
-              fontSize: '16px',
-              fontWeight: 'bold'
-            }}>
-              Menu is {menuOpen ? 'OPEN' : 'CLOSED'}
-            </div>
             {navItems.map((item) => (
               <Link
                 key={item.path}

--- a/my-real-estate-app/src/components/Navbar.jsx
+++ b/my-real-estate-app/src/components/Navbar.jsx
@@ -18,7 +18,11 @@ const Navbar = () => {
   }, []);
 
   const handleMenuToggle = () => {
-    setMenuOpen((open) => !open);
+    console.log('Hamburger clicked! Current menuOpen:', menuOpen);
+    setMenuOpen((open) => {
+      console.log('Previous state:', open, 'New state:', !open);
+      return !open;
+    });
 
     // Add haptic feedback for mobile devices
     if ('vibrate' in navigator) {

--- a/my-real-estate-app/src/components/Navbar.jsx
+++ b/my-real-estate-app/src/components/Navbar.jsx
@@ -18,7 +18,11 @@ const Navbar = () => {
   }, []);
 
   const handleMenuToggle = () => {
-    setMenuOpen((open) => !open);
+    console.log('Hamburger clicked, current menuOpen:', menuOpen);
+    setMenuOpen((open) => {
+      console.log('Setting menuOpen to:', !open);
+      return !open;
+    });
 
     // Add haptic feedback for mobile devices
     if ('vibrate' in navigator) {

--- a/my-real-estate-app/src/styles/MobileOptimizations.css
+++ b/my-real-estate-app/src/styles/MobileOptimizations.css
@@ -163,6 +163,8 @@ html {
   .hamburger {
     padding: 12px;
     cursor: pointer;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: rgba(37, 99, 235, 0.2);
   }
   
   .mobile-nav-link {


### PR DESCRIPTION
## Purpose

Based on user feedback, the mobile navigation menu was not displaying properly and was showing duplicate screens instead of a clean dropdown menu. Users wanted a proper menu that opens directly below the hamburger button with navigation items like Home, Contact Us, About Us, and Projects.

## Code changes

- **Mobile menu positioning**: Changed from full-screen overlay to dropdown menu positioned absolutely below the navbar
- **Menu styling**: Updated mobile menu to use card-style background with border radius and shadow
- **Animation improvements**: Replaced slide-in animation with fade and scale transition for smoother UX
- **Hamburger button**: Enhanced button size, padding, and accessibility attributes
- **Navigation links**: Improved styling with hover effects, active states, and better spacing
- **Touch optimization**: Added touch-action and tap highlight properties for better mobile interaction
- **Theme support**: Added proper dark mode styling for mobile menu elements

The mobile menu now appears as a clean dropdown below the navigation bar instead of a full-screen overlay, providing the expected user experience.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/02e38de9c42642a4ba516c2b669aa3f7/quantum-verse)

👀 [Preview Link](https://02e38de9c42642a4ba516c2b669aa3f7-quantum-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>02e38de9c42642a4ba516c2b669aa3f7</projectId>-->
<!--<branchName>quantum-verse</branchName>-->